### PR TITLE
fix: use es6 set to speed up domain lookups

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,8 +2,8 @@ import { verifyMailboxSMTP } from './smtp';
 import { resolveMxRecords } from './dns';
 import { isValidEmail } from './validator';
 
-let disposableEmailProviders: string[];
-let freeEmailProviders: string[];
+let disposableEmailProviders: Set<string>;
+let freeEmailProviders: Set<string>;
 
 export function isDisposableEmail(emailOrDomain: string): boolean {
   let [_, emailDomain] = emailOrDomain?.split('@');
@@ -14,9 +14,10 @@ export function isDisposableEmail(emailOrDomain: string): boolean {
     return false;
   }
   if (!disposableEmailProviders) {
-    disposableEmailProviders = require('./disposable-email-providers.json');
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    disposableEmailProviders = new Set(require('./disposable-email-providers.json'));
   }
-  return emailDomain && disposableEmailProviders.includes(emailDomain);
+  return emailDomain && disposableEmailProviders.has(emailDomain);
 }
 
 export function isFreeEmail(emailOrDomain: string): boolean {
@@ -29,10 +30,11 @@ export function isFreeEmail(emailOrDomain: string): boolean {
   }
 
   if (!freeEmailProviders) {
-    freeEmailProviders = require('./free-email-providers.json');
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    freeEmailProviders = new Set(require('./free-email-providers.json'));
   }
 
-  return emailDomain && freeEmailProviders.includes(emailDomain);
+  return emailDomain && freeEmailProviders.has(emailDomain);
 }
 
 interface IVerifyEmailResult {


### PR DESCRIPTION
Used [ES6 Sets](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set) to make checks for disposable/free email domains faster (`O(1)` vs `O(n)`). It is a couple of thousand times faster in our test of validating 50.000 email addresses. 