### PR TITLE
feat: support single-letter name extraction from alphanumeric patterns

### DIFF
--- a/__tests__/name-detector-test.ts
+++ b/__tests__/name-detector-test.ts
@@ -231,7 +231,8 @@ describe('Name Detection', () => {
         { email: 'user1.admin2@example.com', firstName: 'User1', lastName: 'Admin2' }, // 'admin' is a reserved suffix, keeps original
         { email: 'dev3.ops4@example.com', firstName: 'Dev', lastName: 'Ops' },
         { email: 'test123.user456@example.com', firstName: 'Test', lastName: 'User' },
-        { email: 'a1.b2@example.com', firstName: 'A1', lastName: 'B2' }, // Too short after cleaning (a, b), keeps original
+        { email: 'a1.b2@example.com', firstName: 'A', lastName: 'B' }, // Now extracts single letters A and B
+        { email: 'j7.d2@example.com', firstName: 'J', lastName: 'D' }, // Should extract single letters J and D
       ];
 
       testCases.forEach(({ email, firstName, lastName }) => {


### PR DESCRIPTION
## Summary
- Enhanced name detection to properly handle patterns like `j7.d2`
- Now correctly extracts single letters as valid names when they appear with numbers
- Improves parsing of email addresses with single-letter initials combined with numbers

## Changes
- Modified `parseCompositeNamePart` function to accept single letters after number removal
- Added `allowSingleLetter` parameter to `isLikelyName` function for explicit single-letter validation
- Updated validation logic to allow single letters in appropriate contexts
- Added test cases for `j7.d2` pattern verification

## Test Results
All tests pass successfully. The implementation now correctly:
- Extracts 'J' and 'D' from `j7.d2@example.com`
- Extracts 'A' and 'B' from `a1.b2@example.com`
- Still extracts 'John' and 'Due' from `john1.due2@example.com`
- Maintains backward compatibility for all other patterns

## Example
```javascript
detectName('j7.d2@example.com')
// Returns: { firstName: 'J', lastName: 'D', confidence: 0.85 }
```

Fixes the handling of single-letter alphanumeric patterns as requested.